### PR TITLE
feat(streaming): add real-time token streaming for all LLM adapters

### DIFF
--- a/.changeset/streaming-feature.md
+++ b/.changeset/streaming-feature.md
@@ -1,0 +1,18 @@
+---
+"@orka-js/core": minor
+"@orka-js/openai": minor
+"@orka-js/anthropic": minor
+"@orka-js/mistral": minor
+"@orka-js/ollama": minor
+---
+
+feat: Add real-time token streaming for all LLM adapters
+
+- Add streaming types and utilities in @orka-js/core (StreamingLLMAdapter, LLMStreamEvent, StreamResult, etc.)
+- Implement stream() and streamGenerate() methods for OpenAI, Anthropic, Mistral, and Ollama adapters
+- Support for token-by-token streaming with onToken and onEvent callbacks
+- Time to First Token (TTFT) tracking for performance monitoring
+- AbortController support for stream cancellation
+- Extended thinking support for Claude models (ThinkingEvent)
+- Event types: token, content, tool_call, thinking, usage, done, error
+- Helper functions: isStreamingAdapter(), createStreamEvent(), consumeStream(), parseSSEStream()

--- a/packages/anthropic/src/index.ts
+++ b/packages/anthropic/src/index.ts
@@ -1,4 +1,20 @@
-import type { LLMAdapter, LLMGenerateOptions, LLMResult, ContentPart } from '@orka-js/core';
+import type {
+  LLMAdapter,
+  LLMGenerateOptions,
+  LLMResult,
+  ContentPart,
+  StreamingLLMAdapter,
+  StreamGenerateOptions,
+  StreamResult,
+  LLMStreamEvent,
+  TokenEvent,
+  ContentEvent,
+  ThinkingEvent,
+  UsageEvent,
+  DoneEvent,
+  ErrorEvent as OrkaErrorEvent,
+} from '@orka-js/core';
+import { createStreamEvent } from '@orka-js/core';
 
 export interface AnthropicAdapterConfig {
   apiKey: string;
@@ -7,8 +23,9 @@ export interface AnthropicAdapterConfig {
   timeoutMs?: number;
 }
 
-export class AnthropicAdapter implements LLMAdapter {
+export class AnthropicAdapter implements LLMAdapter, StreamingLLMAdapter {
   readonly name = 'anthropic';
+  readonly supportsStreaming = true;
   private apiKey: string;
   private model: string;
   private baseURL: string;
@@ -142,5 +159,241 @@ export class AnthropicAdapter implements LLMAdapter {
       case 'tool_use': return 'tool_calls';
       default: return 'stop';
     }
+  }
+
+  /**
+   * Stream generation - returns an AsyncIterable of stream events
+   */
+  async *stream(prompt: string, options: StreamGenerateOptions = {}): AsyncIterable<LLMStreamEvent> {
+    let messages: Array<{ role: string; content: string | unknown[] }>;
+    let system = options.systemPrompt;
+
+    if (options.messages) {
+      messages = [];
+      for (const msg of options.messages) {
+        if (msg.role === 'system') {
+          system = typeof msg.content === 'string' ? msg.content : String(msg.content);
+          continue;
+        }
+        messages.push({
+          role: msg.role,
+          content: msg.content,
+        });
+      }
+    } else {
+      messages = [{ role: 'user', content: prompt }];
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    if (options.signal) {
+      options.signal.addEventListener('abort', () => controller.abort());
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(`${this.baseURL}/v1/messages`, {
+        method: 'POST',
+        signal: controller.signal,
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': this.apiKey,
+          'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify({
+          model: this.model,
+          max_tokens: options.maxTokens ?? 1024,
+          system,
+          messages,
+          temperature: options.temperature ?? 0.7,
+          stop_sequences: options.stopSequences,
+          stream: true,
+        }),
+      });
+    } catch (error) {
+      clearTimeout(timeout);
+      if ((error as Error).name === 'AbortError') {
+        yield createStreamEvent<OrkaErrorEvent>('error', {
+          error: new Error(`Anthropic API request timed out after ${this.timeoutMs}ms`),
+          message: `Request timed out after ${this.timeoutMs}ms`,
+        });
+        return;
+      }
+      yield createStreamEvent<OrkaErrorEvent>('error', {
+        error: error as Error,
+        message: (error as Error).message,
+      });
+      return;
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      yield createStreamEvent<OrkaErrorEvent>('error', {
+        error: new Error(`Anthropic API error: ${response.status} - ${errorText}`),
+        message: `Anthropic API error: ${response.status}`,
+      });
+      return;
+    }
+
+    if (!response.body) {
+      yield createStreamEvent<OrkaErrorEvent>('error', {
+        error: new Error('No response body'),
+        message: 'No response body received',
+      });
+      return;
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let content = '';
+    let _thinking = '';
+    let tokenIndex = 0;
+    let usage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+    let finishReason: LLMResult['finishReason'] = 'stop';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed || !trimmed.startsWith('data: ')) continue;
+
+          try {
+            const json = JSON.parse(trimmed.slice(6));
+            const eventType = json.type;
+
+            switch (eventType) {
+              case 'message_start':
+                if (json.message?.usage) {
+                  usage.promptTokens = json.message.usage.input_tokens || 0;
+                }
+                break;
+
+              case 'content_block_start':
+                // Handle thinking blocks (Claude extended thinking)
+                if (json.content_block?.type === 'thinking') {
+                  _thinking = '';
+                }
+                break;
+
+              case 'content_block_delta':
+                if (json.delta?.type === 'thinking_delta') {
+                  // Extended thinking content
+                  const thinkingDelta = json.delta.thinking || '';
+                  _thinking += thinkingDelta;
+                  yield createStreamEvent<ThinkingEvent>('thinking', {
+                    thinking: _thinking,
+                    delta: thinkingDelta,
+                  });
+                } else if (json.delta?.type === 'text_delta') {
+                  // Regular text content
+                  const token = json.delta.text || '';
+                  content += token;
+
+                  yield createStreamEvent<TokenEvent>('token', {
+                    token,
+                    index: tokenIndex++,
+                  });
+
+                  options.onToken?.(token, tokenIndex - 1);
+
+                  yield createStreamEvent<ContentEvent>('content', {
+                    content,
+                    delta: token,
+                    index: tokenIndex - 1,
+                  });
+                }
+                break;
+
+              case 'message_delta':
+                if (json.delta?.stop_reason) {
+                  finishReason = this.mapStopReason(json.delta.stop_reason);
+                }
+                if (json.usage) {
+                  usage.completionTokens = json.usage.output_tokens || 0;
+                  usage.totalTokens = usage.promptTokens + usage.completionTokens;
+                  yield createStreamEvent<UsageEvent>('usage', { usage });
+                }
+                break;
+
+              case 'message_stop':
+                // Stream complete
+                break;
+            }
+          } catch {
+            // Skip malformed JSON lines
+          }
+        }
+      }
+
+      // Emit done event
+      yield createStreamEvent<DoneEvent>('done', {
+        content,
+        finishReason,
+        usage,
+      });
+
+      options.onEvent?.(createStreamEvent<DoneEvent>('done', {
+        content,
+        finishReason,
+        usage,
+      }));
+
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  /**
+   * Stream generation with final result
+   */
+  async streamGenerate(prompt: string, options: StreamGenerateOptions = {}): Promise<StreamResult> {
+    const startTime = Date.now();
+    let content = '';
+    let tokenIndex = 0;
+    let usage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+    let finishReason: StreamResult['finishReason'] = 'stop';
+    let ttft: number | undefined;
+
+    for await (const event of this.stream(prompt, options)) {
+      options.onEvent?.(event);
+
+      switch (event.type) {
+        case 'token':
+          if (ttft === undefined) ttft = Date.now() - startTime;
+          content += event.token;
+          options.onToken?.(event.token, tokenIndex++);
+          break;
+        case 'usage':
+          usage = event.usage;
+          break;
+        case 'done':
+          content = event.content;
+          finishReason = event.finishReason;
+          if (event.usage) usage = event.usage;
+          break;
+        case 'error':
+          throw event.error;
+      }
+    }
+
+    return {
+      content,
+      usage,
+      model: this.model,
+      finishReason,
+      ttft,
+      durationMs: Date.now() - startTime,
+    };
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,3 +46,27 @@ export {
   type PIIGuardConfig,
   type CustomPIIPattern,
 } from './guard.js';
+
+// Streaming
+export {
+  isStreamingAdapter,
+  createStreamEvent,
+  consumeStream,
+  parseSSEStream,
+  type StreamEventType,
+  type StreamEvent,
+  type TokenEvent,
+  type ContentEvent,
+  type ToolCallEvent,
+  type ToolResultEvent,
+  type ThinkingEvent,
+  type UsageEvent,
+  type DoneEvent,
+  type ErrorEvent,
+  type LLMStreamEvent,
+  type StreamEventHandler,
+  type TokenHandler,
+  type StreamGenerateOptions,
+  type StreamResult,
+  type StreamingLLMAdapter,
+} from './streaming.js';

--- a/packages/core/src/streaming.ts
+++ b/packages/core/src/streaming.ts
@@ -1,0 +1,315 @@
+/**
+ * Streaming types and utilities for OrkaJS
+ * Enables real-time token streaming from LLM providers
+ */
+
+/**
+ * Event types emitted during streaming
+ */
+export type StreamEventType =
+  | 'token'           // Individual token received
+  | 'content'         // Content chunk (may contain multiple tokens)
+  | 'tool_call'       // Tool/function call started
+  | 'tool_result'     // Tool/function result received
+  | 'thinking'        // Model thinking/reasoning (Claude)
+  | 'usage'           // Token usage update
+  | 'done'            // Stream completed
+  | 'error';          // Error occurred
+
+/**
+ * Base stream event
+ */
+export interface StreamEvent {
+  type: StreamEventType;
+  timestamp: number;
+}
+
+/**
+ * Token event - single token received
+ */
+export interface TokenEvent extends StreamEvent {
+  type: 'token';
+  token: string;
+  index: number;
+}
+
+/**
+ * Content event - content chunk (may be multiple tokens)
+ */
+export interface ContentEvent extends StreamEvent {
+  type: 'content';
+  content: string;
+  delta: string;
+  index: number;
+}
+
+/**
+ * Tool call event - function/tool invocation started
+ */
+export interface ToolCallEvent extends StreamEvent {
+  type: 'tool_call';
+  toolCallId: string;
+  name: string;
+  arguments: string;
+}
+
+/**
+ * Tool result event - function/tool result received
+ */
+export interface ToolResultEvent extends StreamEvent {
+  type: 'tool_result';
+  toolCallId: string;
+  result: unknown;
+}
+
+/**
+ * Thinking event - model reasoning (Claude extended thinking)
+ */
+export interface ThinkingEvent extends StreamEvent {
+  type: 'thinking';
+  thinking: string;
+  delta: string;
+}
+
+/**
+ * Usage event - token usage update
+ */
+export interface UsageEvent extends StreamEvent {
+  type: 'usage';
+  usage: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+}
+
+/**
+ * Done event - stream completed
+ */
+export interface DoneEvent extends StreamEvent {
+  type: 'done';
+  content: string;
+  finishReason: 'stop' | 'length' | 'tool_calls' | 'error';
+  usage?: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+}
+
+/**
+ * Error event - error occurred during streaming
+ */
+export interface ErrorEvent extends StreamEvent {
+  type: 'error';
+  error: Error;
+  message: string;
+}
+
+/**
+ * Union of all stream events
+ */
+export type LLMStreamEvent =
+  | TokenEvent
+  | ContentEvent
+  | ToolCallEvent
+  | ToolResultEvent
+  | ThinkingEvent
+  | UsageEvent
+  | DoneEvent
+  | ErrorEvent;
+
+/**
+ * Callback for handling stream events
+ */
+export type StreamEventHandler = (event: LLMStreamEvent) => void;
+
+/**
+ * Callback for handling individual tokens
+ */
+export type TokenHandler = (token: string, index: number) => void;
+
+/**
+ * Options for streaming generation
+ */
+export interface StreamGenerateOptions {
+  temperature?: number;
+  maxTokens?: number;
+  stopSequences?: string[];
+  systemPrompt?: string;
+  messages?: Array<{
+    role: 'system' | 'user' | 'assistant';
+    content: string | unknown[];
+  }>;
+  /** Callback for each token */
+  onToken?: TokenHandler;
+  /** Callback for each stream event */
+  onEvent?: StreamEventHandler;
+  /** AbortController signal for cancellation */
+  signal?: AbortSignal;
+}
+
+/**
+ * Result of a streaming generation
+ */
+export interface StreamResult {
+  content: string;
+  usage: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+  model: string;
+  finishReason: 'stop' | 'length' | 'tool_calls' | 'error';
+  /** Time to first token in milliseconds */
+  ttft?: number;
+  /** Total streaming duration in milliseconds */
+  durationMs: number;
+}
+
+/**
+ * Interface for LLM adapters that support streaming
+ */
+export interface StreamingLLMAdapter {
+  /**
+   * Generate a response with streaming
+   * @param prompt - The prompt to send
+   * @param options - Streaming options including callbacks
+   * @returns AsyncIterable of stream events
+   */
+  stream(prompt: string, options?: StreamGenerateOptions): AsyncIterable<LLMStreamEvent>;
+
+  /**
+   * Generate a response with streaming, returning final result
+   * @param prompt - The prompt to send
+   * @param options - Streaming options including callbacks
+   * @returns Promise resolving to the final result
+   */
+  streamGenerate(prompt: string, options?: StreamGenerateOptions): Promise<StreamResult>;
+
+  /**
+   * Check if this adapter supports streaming
+   */
+  readonly supportsStreaming: boolean;
+}
+
+/**
+ * Type guard to check if an adapter supports streaming
+ */
+export function isStreamingAdapter(adapter: unknown): adapter is StreamingLLMAdapter {
+  return (
+    typeof adapter === 'object' &&
+    adapter !== null &&
+    'stream' in adapter &&
+    'streamGenerate' in adapter &&
+    'supportsStreaming' in adapter &&
+    (adapter as StreamingLLMAdapter).supportsStreaming === true
+  );
+}
+
+/**
+ * Helper to create a stream event
+ */
+export function createStreamEvent<T extends LLMStreamEvent>(
+  type: T['type'],
+  data: Omit<T, 'type' | 'timestamp'>
+): T {
+  return {
+    type,
+    timestamp: Date.now(),
+    ...data,
+  } as T;
+}
+
+/**
+ * Async iterator helper for consuming streams
+ */
+export async function consumeStream(
+  stream: AsyncIterable<LLMStreamEvent>,
+  handlers?: {
+    onToken?: TokenHandler;
+    onEvent?: StreamEventHandler;
+  }
+): Promise<StreamResult> {
+  let content = '';
+  let tokenIndex = 0;
+  let usage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+  let finishReason: StreamResult['finishReason'] = 'stop';
+  let model = '';
+  const startTime = Date.now();
+  let ttft: number | undefined;
+
+  for await (const event of stream) {
+    handlers?.onEvent?.(event);
+
+    switch (event.type) {
+      case 'token':
+        if (ttft === undefined) ttft = Date.now() - startTime;
+        content += event.token;
+        handlers?.onToken?.(event.token, tokenIndex++);
+        break;
+      case 'content':
+        if (ttft === undefined) ttft = Date.now() - startTime;
+        content = event.content;
+        break;
+      case 'usage':
+        usage = event.usage;
+        break;
+      case 'done':
+        content = event.content;
+        finishReason = event.finishReason;
+        if (event.usage) usage = event.usage;
+        break;
+      case 'error':
+        throw event.error;
+    }
+  }
+
+  return {
+    content,
+    usage,
+    model,
+    finishReason,
+    ttft,
+    durationMs: Date.now() - startTime,
+  };
+}
+
+/**
+ * Transform a ReadableStream into an AsyncIterable of stream events
+ * Used internally by adapters to parse SSE streams
+ */
+export async function* parseSSEStream(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  parser: (line: string) => LLMStreamEvent | null
+): AsyncIterable<LLMStreamEvent> {
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith(':')) continue;
+
+        const event = parser(trimmed);
+        if (event) yield event;
+      }
+    }
+
+    // Process remaining buffer
+    if (buffer.trim()) {
+      const event = parser(buffer.trim());
+      if (event) yield event;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/packages/mistral/src/index.ts
+++ b/packages/mistral/src/index.ts
@@ -1,4 +1,18 @@
-import type { LLMAdapter, LLMGenerateOptions, LLMResult } from '@orka-js/core';
+import type {
+  LLMAdapter,
+  LLMGenerateOptions,
+  LLMResult,
+  StreamingLLMAdapter,
+  StreamGenerateOptions,
+  StreamResult,
+  LLMStreamEvent,
+  TokenEvent,
+  ContentEvent,
+  UsageEvent,
+  DoneEvent,
+  ErrorEvent as OrkaErrorEvent,
+} from '@orka-js/core';
+import { createStreamEvent } from '@orka-js/core';
 
 export interface MistralAdapterConfig {
   apiKey: string;
@@ -8,8 +22,9 @@ export interface MistralAdapterConfig {
   timeoutMs?: number;
 }
 
-export class MistralAdapter implements LLMAdapter {
+export class MistralAdapter implements LLMAdapter, StreamingLLMAdapter {
   readonly name = 'mistral';
+  readonly supportsStreaming = true;
   private apiKey: string;
   private model: string;
   private embeddingModel: string;
@@ -136,5 +151,202 @@ export class MistralAdapter implements LLMAdapter {
       case 'tool_calls': return 'tool_calls';
       default: return 'stop';
     }
+  }
+
+  /**
+   * Stream generation - returns an AsyncIterable of stream events
+   * Mistral API is OpenAI-compatible for streaming
+   */
+  async *stream(prompt: string, options: StreamGenerateOptions = {}): AsyncIterable<LLMStreamEvent> {
+    const messages: Array<{ role: string; content: string }> = [];
+
+    if (options.systemPrompt) {
+      messages.push({ role: 'system', content: options.systemPrompt });
+    }
+    messages.push({ role: 'user', content: prompt });
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    if (options.signal) {
+      options.signal.addEventListener('abort', () => controller.abort());
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(`${this.baseURL}/chat/completions`, {
+        method: 'POST',
+        signal: controller.signal,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify({
+          model: this.model,
+          messages,
+          temperature: options.temperature ?? 0.7,
+          max_tokens: options.maxTokens ?? 1024,
+          stop: options.stopSequences,
+          stream: true,
+        }),
+      });
+    } catch (error) {
+      clearTimeout(timeout);
+      if ((error as Error).name === 'AbortError') {
+        yield createStreamEvent<OrkaErrorEvent>('error', {
+          error: new Error(`Mistral API request timed out after ${this.timeoutMs}ms`),
+          message: `Request timed out after ${this.timeoutMs}ms`,
+        });
+        return;
+      }
+      yield createStreamEvent<OrkaErrorEvent>('error', {
+        error: error as Error,
+        message: (error as Error).message,
+      });
+      return;
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      yield createStreamEvent<OrkaErrorEvent>('error', {
+        error: new Error(`Mistral API error: ${response.status} - ${errorText}`),
+        message: `Mistral API error: ${response.status}`,
+      });
+      return;
+    }
+
+    if (!response.body) {
+      yield createStreamEvent<OrkaErrorEvent>('error', {
+        error: new Error('No response body'),
+        message: 'No response body received',
+      });
+      return;
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let content = '';
+    let tokenIndex = 0;
+    let usage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+    let finishReason: LLMResult['finishReason'] = 'stop';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed || trimmed === 'data: [DONE]') continue;
+          if (!trimmed.startsWith('data: ')) continue;
+
+          try {
+            const json = JSON.parse(trimmed.slice(6));
+
+            if (json.usage) {
+              usage = {
+                promptTokens: json.usage.prompt_tokens || 0,
+                completionTokens: json.usage.completion_tokens || 0,
+                totalTokens: json.usage.total_tokens || 0,
+              };
+              yield createStreamEvent<UsageEvent>('usage', { usage });
+            }
+
+            const choice = json.choices?.[0];
+            if (!choice) continue;
+
+            if (choice.finish_reason) {
+              finishReason = this.mapFinishReason(choice.finish_reason);
+            }
+
+            const delta = choice.delta;
+            if (delta?.content) {
+              const token = delta.content;
+              content += token;
+
+              yield createStreamEvent<TokenEvent>('token', {
+                token,
+                index: tokenIndex++,
+              });
+
+              options.onToken?.(token, tokenIndex - 1);
+
+              yield createStreamEvent<ContentEvent>('content', {
+                content,
+                delta: token,
+                index: tokenIndex - 1,
+              });
+            }
+          } catch {
+            // Skip malformed JSON
+          }
+        }
+      }
+
+      yield createStreamEvent<DoneEvent>('done', {
+        content,
+        finishReason,
+        usage,
+      });
+
+      options.onEvent?.(createStreamEvent<DoneEvent>('done', {
+        content,
+        finishReason,
+        usage,
+      }));
+
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  /**
+   * Stream generation with final result
+   */
+  async streamGenerate(prompt: string, options: StreamGenerateOptions = {}): Promise<StreamResult> {
+    const startTime = Date.now();
+    let content = '';
+    let tokenIndex = 0;
+    let usage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+    let finishReason: StreamResult['finishReason'] = 'stop';
+    let ttft: number | undefined;
+
+    for await (const event of this.stream(prompt, options)) {
+      options.onEvent?.(event);
+
+      switch (event.type) {
+        case 'token':
+          if (ttft === undefined) ttft = Date.now() - startTime;
+          content += event.token;
+          options.onToken?.(event.token, tokenIndex++);
+          break;
+        case 'usage':
+          usage = event.usage;
+          break;
+        case 'done':
+          content = event.content;
+          finishReason = event.finishReason;
+          if (event.usage) usage = event.usage;
+          break;
+        case 'error':
+          throw event.error;
+      }
+    }
+
+    return {
+      content,
+      usage,
+      model: this.model,
+      finishReason,
+      ttft,
+      durationMs: Date.now() - startTime,
+    };
   }
 }

--- a/packages/ollama/src/index.ts
+++ b/packages/ollama/src/index.ts
@@ -1,4 +1,18 @@
-import type { LLMAdapter, LLMGenerateOptions, LLMResult } from '@orka-js/core';
+import type {
+  LLMAdapter,
+  LLMGenerateOptions,
+  LLMResult,
+  StreamingLLMAdapter,
+  StreamGenerateOptions,
+  StreamResult,
+  LLMStreamEvent,
+  TokenEvent,
+  ContentEvent,
+  UsageEvent,
+  DoneEvent,
+  ErrorEvent as OrkaErrorEvent,
+} from '@orka-js/core';
+import { createStreamEvent } from '@orka-js/core';
 
 export interface OllamaAdapterConfig {
   model?: string;
@@ -7,8 +21,9 @@ export interface OllamaAdapterConfig {
   timeoutMs?: number;
 }
 
-export class OllamaAdapter implements LLMAdapter {
+export class OllamaAdapter implements LLMAdapter, StreamingLLMAdapter {
   readonly name = 'ollama';
+  readonly supportsStreaming = true;
   private model: string;
   private embeddingModel: string;
   private baseURL: string;
@@ -123,5 +138,193 @@ export class OllamaAdapter implements LLMAdapter {
     }
 
     return embeddings;
+  }
+
+  /**
+   * Stream generation - returns an AsyncIterable of stream events
+   * Ollama uses NDJSON streaming format
+   */
+  async *stream(prompt: string, options: StreamGenerateOptions = {}): AsyncIterable<LLMStreamEvent> {
+    const messages: Array<{ role: string; content: string }> = [];
+
+    if (options.systemPrompt) {
+      messages.push({ role: 'system', content: options.systemPrompt });
+    }
+    messages.push({ role: 'user', content: prompt });
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    if (options.signal) {
+      options.signal.addEventListener('abort', () => controller.abort());
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(`${this.baseURL}/api/chat`, {
+        method: 'POST',
+        signal: controller.signal,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: this.model,
+          messages,
+          stream: true,
+          options: {
+            temperature: options.temperature ?? 0.7,
+            num_predict: options.maxTokens ?? 1024,
+            stop: options.stopSequences,
+          },
+        }),
+      });
+    } catch (error) {
+      clearTimeout(timeout);
+      if ((error as Error).name === 'AbortError') {
+        yield createStreamEvent<OrkaErrorEvent>('error', {
+          error: new Error(`Ollama API request timed out after ${this.timeoutMs}ms`),
+          message: `Request timed out after ${this.timeoutMs}ms`,
+        });
+        return;
+      }
+      yield createStreamEvent<OrkaErrorEvent>('error', {
+        error: error as Error,
+        message: (error as Error).message,
+      });
+      return;
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      yield createStreamEvent<OrkaErrorEvent>('error', {
+        error: new Error(`Ollama API error: ${response.status} - ${errorText}`),
+        message: `Ollama API error: ${response.status}`,
+      });
+      return;
+    }
+
+    if (!response.body) {
+      yield createStreamEvent<OrkaErrorEvent>('error', {
+        error: new Error('No response body'),
+        message: 'No response body received',
+      });
+      return;
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let content = '';
+    let tokenIndex = 0;
+    let usage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+
+          try {
+            const json = JSON.parse(trimmed);
+
+            // Ollama streams message content
+            if (json.message?.content) {
+              const token = json.message.content;
+              content += token;
+
+              yield createStreamEvent<TokenEvent>('token', {
+                token,
+                index: tokenIndex++,
+              });
+
+              options.onToken?.(token, tokenIndex - 1);
+
+              yield createStreamEvent<ContentEvent>('content', {
+                content,
+                delta: token,
+                index: tokenIndex - 1,
+              });
+            }
+
+            // Final message with usage stats
+            if (json.done) {
+              usage = {
+                promptTokens: json.prompt_eval_count || 0,
+                completionTokens: json.eval_count || 0,
+                totalTokens: (json.prompt_eval_count || 0) + (json.eval_count || 0),
+              };
+              yield createStreamEvent<UsageEvent>('usage', { usage });
+            }
+          } catch {
+            // Skip malformed JSON
+          }
+        }
+      }
+
+      yield createStreamEvent<DoneEvent>('done', {
+        content,
+        finishReason: 'stop',
+        usage,
+      });
+
+      options.onEvent?.(createStreamEvent<DoneEvent>('done', {
+        content,
+        finishReason: 'stop',
+        usage,
+      }));
+
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  /**
+   * Stream generation with final result
+   */
+  async streamGenerate(prompt: string, options: StreamGenerateOptions = {}): Promise<StreamResult> {
+    const startTime = Date.now();
+    let content = '';
+    let tokenIndex = 0;
+    let usage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+    let finishReason: StreamResult['finishReason'] = 'stop';
+    let ttft: number | undefined;
+
+    for await (const event of this.stream(prompt, options)) {
+      options.onEvent?.(event);
+
+      switch (event.type) {
+        case 'token':
+          if (ttft === undefined) ttft = Date.now() - startTime;
+          content += event.token;
+          options.onToken?.(event.token, tokenIndex++);
+          break;
+        case 'usage':
+          usage = event.usage;
+          break;
+        case 'done':
+          content = event.content;
+          finishReason = event.finishReason;
+          if (event.usage) usage = event.usage;
+          break;
+        case 'error':
+          throw event.error;
+      }
+    }
+
+    return {
+      content,
+      usage,
+      model: this.model,
+      finishReason,
+      ttft,
+      durationMs: Date.now() - startTime,
+    };
   }
 }

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -1,4 +1,20 @@
-import type { LLMAdapter, LLMGenerateOptions, LLMResult, ContentPart } from '@orka-js/core';
+import type {
+  LLMAdapter,
+  LLMGenerateOptions,
+  LLMResult,
+  ContentPart,
+  StreamingLLMAdapter,
+  StreamGenerateOptions,
+  StreamResult,
+  LLMStreamEvent,
+  TokenEvent,
+  ContentEvent,
+  ToolCallEvent,
+  UsageEvent,
+  DoneEvent,
+  ErrorEvent as OrkaErrorEvent,
+} from '@orka-js/core';
+import { createStreamEvent } from '@orka-js/core';
 
 export interface OpenAIAdapterConfig {
   apiKey: string;
@@ -8,8 +24,9 @@ export interface OpenAIAdapterConfig {
   timeoutMs?: number;
 }
 
-export class OpenAIAdapter implements LLMAdapter {
+export class OpenAIAdapter implements LLMAdapter, StreamingLLMAdapter {
   readonly name = 'openai';
+  readonly supportsStreaming = true;
   private apiKey: string;
   private model: string;
   private embeddingModel: string;
@@ -170,5 +187,236 @@ export class OpenAIAdapter implements LLMAdapter {
       case 'tool_calls': return 'tool_calls';
       default: return 'stop';
     }
+  }
+
+  /**
+   * Stream generation - returns an AsyncIterable of stream events
+   */
+  async *stream(prompt: string, options: StreamGenerateOptions = {}): AsyncIterable<LLMStreamEvent> {
+    const messages: Array<{ role: string; content: string | unknown[] }> = [];
+
+    if (options.messages) {
+      for (const msg of options.messages) {
+        messages.push({
+          role: msg.role,
+          content: typeof msg.content === 'string'
+            ? msg.content
+            : msg.content,
+        });
+      }
+    } else {
+      if (options.systemPrompt) {
+        messages.push({ role: 'system', content: options.systemPrompt });
+      }
+      messages.push({ role: 'user', content: prompt });
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    // Combine with external signal if provided
+    if (options.signal) {
+      options.signal.addEventListener('abort', () => controller.abort());
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(`${this.baseURL}/chat/completions`, {
+        method: 'POST',
+        signal: controller.signal,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify({
+          model: this.model,
+          messages,
+          temperature: options.temperature ?? 0.7,
+          max_tokens: options.maxTokens ?? 1024,
+          stop: options.stopSequences,
+          stream: true,
+          stream_options: { include_usage: true },
+        }),
+      });
+    } catch (error) {
+      clearTimeout(timeout);
+      if ((error as Error).name === 'AbortError') {
+        yield createStreamEvent<OrkaErrorEvent>('error', {
+          error: new Error(`OpenAI API request timed out after ${this.timeoutMs}ms`),
+          message: `Request timed out after ${this.timeoutMs}ms`,
+        });
+        return;
+      }
+      yield createStreamEvent<OrkaErrorEvent>('error', {
+        error: error as Error,
+        message: (error as Error).message,
+      });
+      return;
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      yield createStreamEvent<OrkaErrorEvent>('error', {
+        error: new Error(`OpenAI API error: ${response.status} - ${errorText}`),
+        message: `OpenAI API error: ${response.status}`,
+      });
+      return;
+    }
+
+    if (!response.body) {
+      yield createStreamEvent<OrkaErrorEvent>('error', {
+        error: new Error('No response body'),
+        message: 'No response body received',
+      });
+      return;
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let content = '';
+    let tokenIndex = 0;
+    let usage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+    let finishReason: LLMResult['finishReason'] = 'stop';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed || trimmed === 'data: [DONE]') continue;
+          if (!trimmed.startsWith('data: ')) continue;
+
+          try {
+            const json = JSON.parse(trimmed.slice(6));
+            
+            // Handle usage info (comes at the end with stream_options)
+            if (json.usage) {
+              usage = {
+                promptTokens: json.usage.prompt_tokens,
+                completionTokens: json.usage.completion_tokens,
+                totalTokens: json.usage.total_tokens,
+              };
+              yield createStreamEvent<UsageEvent>('usage', { usage });
+            }
+
+            const choice = json.choices?.[0];
+            if (!choice) continue;
+
+            // Handle finish reason
+            if (choice.finish_reason) {
+              finishReason = this.mapFinishReason(choice.finish_reason);
+            }
+
+            // Handle content delta
+            const delta = choice.delta;
+            if (delta?.content) {
+              const token = delta.content;
+              content += token;
+              
+              // Emit token event
+              yield createStreamEvent<TokenEvent>('token', {
+                token,
+                index: tokenIndex++,
+              });
+
+              // Call onToken callback if provided
+              options.onToken?.(token, tokenIndex - 1);
+
+              // Emit content event
+              yield createStreamEvent<ContentEvent>('content', {
+                content,
+                delta: token,
+                index: tokenIndex - 1,
+              });
+            }
+
+            // Handle tool calls
+            if (delta?.tool_calls) {
+              for (const toolCall of delta.tool_calls) {
+                if (toolCall.function) {
+                  yield createStreamEvent<ToolCallEvent>('tool_call', {
+                    toolCallId: toolCall.id || '',
+                    name: toolCall.function.name || '',
+                    arguments: toolCall.function.arguments || '',
+                  });
+                }
+              }
+            }
+          } catch {
+            // Skip malformed JSON lines
+          }
+        }
+      }
+
+      // Emit done event
+      yield createStreamEvent<DoneEvent>('done', {
+        content,
+        finishReason,
+        usage,
+      });
+
+      // Call onEvent callback for done
+      options.onEvent?.(createStreamEvent<DoneEvent>('done', {
+        content,
+        finishReason,
+        usage,
+      }));
+
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  /**
+   * Stream generation with final result - convenience method
+   */
+  async streamGenerate(prompt: string, options: StreamGenerateOptions = {}): Promise<StreamResult> {
+    const startTime = Date.now();
+    let content = '';
+    let tokenIndex = 0;
+    let usage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+    let finishReason: StreamResult['finishReason'] = 'stop';
+    let ttft: number | undefined;
+
+    for await (const event of this.stream(prompt, options)) {
+      // Call event handler
+      options.onEvent?.(event);
+
+      switch (event.type) {
+        case 'token':
+          if (ttft === undefined) ttft = Date.now() - startTime;
+          content += event.token;
+          options.onToken?.(event.token, tokenIndex++);
+          break;
+        case 'usage':
+          usage = event.usage;
+          break;
+        case 'done':
+          content = event.content;
+          finishReason = event.finishReason;
+          if (event.usage) usage = event.usage;
+          break;
+        case 'error':
+          throw event.error;
+      }
+    }
+
+    return {
+      content,
+      usage,
+      model: this.model,
+      finishReason,
+      ttft,
+      durationMs: Date.now() - startTime,
+    };
   }
 }

--- a/tests/unit/streaming/streaming.test.ts
+++ b/tests/unit/streaming/streaming.test.ts
@@ -1,0 +1,371 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  isStreamingAdapter,
+  createStreamEvent,
+  consumeStream,
+  type LLMStreamEvent,
+  type TokenEvent,
+  type ContentEvent,
+  type DoneEvent,
+  type ErrorEvent,
+  type UsageEvent,
+  type StreamResult,
+} from '@orka-js/core';
+
+describe('Streaming', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('isStreamingAdapter', () => {
+    it('should return true for valid streaming adapter', () => {
+      const adapter = {
+        stream: async function* () { yield {} as LLMStreamEvent; },
+        streamGenerate: async () => ({} as StreamResult),
+        supportsStreaming: true,
+      };
+
+      expect(isStreamingAdapter(adapter)).toBe(true);
+    });
+
+    it('should return false for non-streaming adapter', () => {
+      const adapter = {
+        generate: async () => ({}),
+        embed: async () => [],
+        name: 'test',
+      };
+
+      expect(isStreamingAdapter(adapter)).toBe(false);
+    });
+
+    it('should return false for adapter with supportsStreaming = false', () => {
+      const adapter = {
+        stream: async function* () { yield {} as LLMStreamEvent; },
+        streamGenerate: async () => ({} as StreamResult),
+        supportsStreaming: false,
+      };
+
+      expect(isStreamingAdapter(adapter)).toBe(false);
+    });
+
+    it('should return false for null', () => {
+      expect(isStreamingAdapter(null)).toBe(false);
+    });
+
+    it('should return false for undefined', () => {
+      expect(isStreamingAdapter(undefined)).toBe(false);
+    });
+  });
+
+  describe('createStreamEvent', () => {
+    it('should create token event with timestamp', () => {
+      const event = createStreamEvent<TokenEvent>('token', {
+        token: 'Hello',
+        index: 0,
+      });
+
+      expect(event.type).toBe('token');
+      expect(event.token).toBe('Hello');
+      expect(event.index).toBe(0);
+      expect(event.timestamp).toBeDefined();
+      expect(typeof event.timestamp).toBe('number');
+    });
+
+    it('should create content event', () => {
+      const event = createStreamEvent<ContentEvent>('content', {
+        content: 'Hello World',
+        delta: 'World',
+        index: 1,
+      });
+
+      expect(event.type).toBe('content');
+      expect(event.content).toBe('Hello World');
+      expect(event.delta).toBe('World');
+      expect(event.index).toBe(1);
+    });
+
+    it('should create done event', () => {
+      const event = createStreamEvent<DoneEvent>('done', {
+        content: 'Complete response',
+        finishReason: 'stop',
+        usage: {
+          promptTokens: 10,
+          completionTokens: 20,
+          totalTokens: 30,
+        },
+      });
+
+      expect(event.type).toBe('done');
+      expect(event.content).toBe('Complete response');
+      expect(event.finishReason).toBe('stop');
+      expect(event.usage?.totalTokens).toBe(30);
+    });
+
+    it('should create error event', () => {
+      const error = new Error('Test error');
+      const event = createStreamEvent<ErrorEvent>('error', {
+        error,
+        message: 'Test error message',
+      });
+
+      expect(event.type).toBe('error');
+      expect(event.error).toBe(error);
+      expect(event.message).toBe('Test error message');
+    });
+
+    it('should create usage event', () => {
+      const event = createStreamEvent<UsageEvent>('usage', {
+        usage: {
+          promptTokens: 100,
+          completionTokens: 200,
+          totalTokens: 300,
+        },
+      });
+
+      expect(event.type).toBe('usage');
+      expect(event.usage.promptTokens).toBe(100);
+      expect(event.usage.completionTokens).toBe(200);
+      expect(event.usage.totalTokens).toBe(300);
+    });
+  });
+
+  describe('consumeStream', () => {
+    it('should consume stream and return final result', async () => {
+      async function* mockStream(): AsyncIterable<LLMStreamEvent> {
+        yield createStreamEvent<TokenEvent>('token', { token: 'Hello', index: 0 });
+        yield createStreamEvent<TokenEvent>('token', { token: ' ', index: 1 });
+        yield createStreamEvent<TokenEvent>('token', { token: 'World', index: 2 });
+        yield createStreamEvent<UsageEvent>('usage', {
+          usage: { promptTokens: 5, completionTokens: 3, totalTokens: 8 },
+        });
+        yield createStreamEvent<DoneEvent>('done', {
+          content: 'Hello World',
+          finishReason: 'stop',
+          usage: { promptTokens: 5, completionTokens: 3, totalTokens: 8 },
+        });
+      }
+
+      const result = await consumeStream(mockStream());
+
+      expect(result.content).toBe('Hello World');
+      expect(result.finishReason).toBe('stop');
+      expect(result.usage.totalTokens).toBe(8);
+      expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should call onToken handler for each token', async () => {
+      const onToken = vi.fn();
+
+      async function* mockStream(): AsyncIterable<LLMStreamEvent> {
+        yield createStreamEvent<TokenEvent>('token', { token: 'A', index: 0 });
+        yield createStreamEvent<TokenEvent>('token', { token: 'B', index: 1 });
+        yield createStreamEvent<TokenEvent>('token', { token: 'C', index: 2 });
+        yield createStreamEvent<DoneEvent>('done', {
+          content: 'ABC',
+          finishReason: 'stop',
+        });
+      }
+
+      await consumeStream(mockStream(), { onToken });
+
+      expect(onToken).toHaveBeenCalledTimes(3);
+      expect(onToken).toHaveBeenNthCalledWith(1, 'A', 0);
+      expect(onToken).toHaveBeenNthCalledWith(2, 'B', 1);
+      expect(onToken).toHaveBeenNthCalledWith(3, 'C', 2);
+    });
+
+    it('should call onEvent handler for each event', async () => {
+      const onEvent = vi.fn();
+
+      async function* mockStream(): AsyncIterable<LLMStreamEvent> {
+        yield createStreamEvent<TokenEvent>('token', { token: 'X', index: 0 });
+        yield createStreamEvent<DoneEvent>('done', {
+          content: 'X',
+          finishReason: 'stop',
+        });
+      }
+
+      await consumeStream(mockStream(), { onEvent });
+
+      expect(onEvent).toHaveBeenCalledTimes(2);
+      expect(onEvent.mock.calls[0][0].type).toBe('token');
+      expect(onEvent.mock.calls[1][0].type).toBe('done');
+    });
+
+    it('should throw on error event', async () => {
+      const testError = new Error('Stream error');
+
+      async function* mockStream(): AsyncIterable<LLMStreamEvent> {
+        yield createStreamEvent<TokenEvent>('token', { token: 'Start', index: 0 });
+        yield createStreamEvent<ErrorEvent>('error', {
+          error: testError,
+          message: 'Stream error',
+        });
+      }
+
+      await expect(consumeStream(mockStream())).rejects.toThrow('Stream error');
+    });
+
+    it('should track time to first token', async () => {
+      async function* mockStream(): AsyncIterable<LLMStreamEvent> {
+        yield createStreamEvent<TokenEvent>('token', { token: 'First', index: 0 });
+        yield createStreamEvent<DoneEvent>('done', {
+          content: 'First',
+          finishReason: 'stop',
+        });
+      }
+
+      const result = await consumeStream(mockStream());
+
+      expect(result.ttft).toBeDefined();
+      expect(result.ttft).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should handle content events', async () => {
+      async function* mockStream(): AsyncIterable<LLMStreamEvent> {
+        yield createStreamEvent<ContentEvent>('content', {
+          content: 'Hello',
+          delta: 'Hello',
+          index: 0,
+        });
+        yield createStreamEvent<ContentEvent>('content', {
+          content: 'Hello World',
+          delta: ' World',
+          index: 1,
+        });
+        yield createStreamEvent<DoneEvent>('done', {
+          content: 'Hello World',
+          finishReason: 'stop',
+        });
+      }
+
+      const result = await consumeStream(mockStream());
+
+      expect(result.content).toBe('Hello World');
+    });
+  });
+
+  describe('Stream Event Types', () => {
+    it('should support all event types', () => {
+      const eventTypes: LLMStreamEvent['type'][] = [
+        'token',
+        'content',
+        'tool_call',
+        'tool_result',
+        'thinking',
+        'usage',
+        'done',
+        'error',
+      ];
+
+      expect(eventTypes).toHaveLength(8);
+    });
+
+    it('should support all finish reasons', () => {
+      const finishReasons: DoneEvent['finishReason'][] = [
+        'stop',
+        'length',
+        'tool_calls',
+        'error',
+      ];
+
+      expect(finishReasons).toHaveLength(4);
+    });
+  });
+});
+
+describe('OpenAI Streaming Adapter', () => {
+  it('should have supportsStreaming property', async () => {
+    const { OpenAIAdapter } = await import('@orka-js/openai');
+    const adapter = new OpenAIAdapter({ apiKey: 'test-key' });
+
+    expect(adapter.supportsStreaming).toBe(true);
+    expect(isStreamingAdapter(adapter)).toBe(true);
+  });
+
+  it('should have stream method', async () => {
+    const { OpenAIAdapter } = await import('@orka-js/openai');
+    const adapter = new OpenAIAdapter({ apiKey: 'test-key' });
+
+    expect(typeof adapter.stream).toBe('function');
+  });
+
+  it('should have streamGenerate method', async () => {
+    const { OpenAIAdapter } = await import('@orka-js/openai');
+    const adapter = new OpenAIAdapter({ apiKey: 'test-key' });
+
+    expect(typeof adapter.streamGenerate).toBe('function');
+  });
+});
+
+describe('Anthropic Streaming Adapter', () => {
+  it('should have supportsStreaming property', async () => {
+    const { AnthropicAdapter } = await import('@orka-js/anthropic');
+    const adapter = new AnthropicAdapter({ apiKey: 'test-key' });
+
+    expect(adapter.supportsStreaming).toBe(true);
+    expect(isStreamingAdapter(adapter)).toBe(true);
+  });
+
+  it('should have stream method', async () => {
+    const { AnthropicAdapter } = await import('@orka-js/anthropic');
+    const adapter = new AnthropicAdapter({ apiKey: 'test-key' });
+
+    expect(typeof adapter.stream).toBe('function');
+  });
+
+  it('should have streamGenerate method', async () => {
+    const { AnthropicAdapter } = await import('@orka-js/anthropic');
+    const adapter = new AnthropicAdapter({ apiKey: 'test-key' });
+
+    expect(typeof adapter.streamGenerate).toBe('function');
+  });
+});
+
+describe('Mistral Streaming Adapter', () => {
+  it('should have supportsStreaming property', async () => {
+    const { MistralAdapter } = await import('@orka-js/mistral');
+    const adapter = new MistralAdapter({ apiKey: 'test-key' });
+
+    expect(adapter.supportsStreaming).toBe(true);
+    expect(isStreamingAdapter(adapter)).toBe(true);
+  });
+
+  it('should have stream method', async () => {
+    const { MistralAdapter } = await import('@orka-js/mistral');
+    const adapter = new MistralAdapter({ apiKey: 'test-key' });
+
+    expect(typeof adapter.stream).toBe('function');
+  });
+
+  it('should have streamGenerate method', async () => {
+    const { MistralAdapter } = await import('@orka-js/mistral');
+    const adapter = new MistralAdapter({ apiKey: 'test-key' });
+
+    expect(typeof adapter.streamGenerate).toBe('function');
+  });
+});
+
+describe('Ollama Streaming Adapter', () => {
+  it('should have supportsStreaming property', async () => {
+    const { OllamaAdapter } = await import('@orka-js/ollama');
+    const adapter = new OllamaAdapter();
+
+    expect(adapter.supportsStreaming).toBe(true);
+    expect(isStreamingAdapter(adapter)).toBe(true);
+  });
+
+  it('should have stream method', async () => {
+    const { OllamaAdapter } = await import('@orka-js/ollama');
+    const adapter = new OllamaAdapter();
+
+    expect(typeof adapter.stream).toBe('function');
+  });
+
+  it('should have streamGenerate method', async () => {
+    const { OllamaAdapter } = await import('@orka-js/ollama');
+    const adapter = new OllamaAdapter();
+
+    expect(typeof adapter.streamGenerate).toBe('function');
+  });
+});


### PR DESCRIPTION
- Add streaming types and utilities in @orka-js/core
- Implement stream() and streamGenerate() for OpenAI, Anthropic, Mistral, Ollama
- Support onToken/onEvent callbacks, TTFT tracking, AbortController
- Extended thinking support for Claude models
- Add 30 unit tests for streaming functionality